### PR TITLE
Remove explicit C# LangVersion from Agents.console.csproj

### DIFF
--- a/Agents.console/Agents.console.csproj
+++ b/Agents.console/Agents.console.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Agents_console</RootNamespace>
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `<LangVersion>` element specifying C# 7.1 was removed from the `<PropertyGroup>` section of the project file. The project will now use the default language version determined by the .NET SDK for the target framework `net9.0`.